### PR TITLE
feat(grid): add defaultDefinitions property

### DIFF
--- a/packages/core/src/components.d.ts
+++ b/packages/core/src/components.d.ts
@@ -256,6 +256,10 @@ export namespace Components {
      */
     data: DataItem[];
     /**
+     * Default grid headers
+     */
+    defaultDefinitions?: ColumnDefinition<DataItem>[];
+    /**
      * Grid headers
      */
     definitions: ColumnDefinition<DataItem>[];
@@ -1373,6 +1377,10 @@ declare namespace LocalJSX {
      * Grid rows
      */
     data: DataItem[];
+    /**
+     * Default grid headers
+     */
+    defaultDefinitions?: ColumnDefinition<DataItem>[];
     /**
      * Grid headers
      */

--- a/packages/core/src/components/organisms/p6-grid/p6-grid.tsx
+++ b/packages/core/src/components/organisms/p6-grid/p6-grid.tsx
@@ -54,6 +54,11 @@ export class P6Grid {
   @Prop() definitions!: ColumnDefinition<DataItem>[];
 
   /**
+   * Default grid headers
+   */
+  @Prop() defaultDefinitions?: ColumnDefinition<DataItem>[];
+
+  /**
    * Grid rows
    */
   @Prop() data!: DataItem[];
@@ -178,7 +183,7 @@ export class P6Grid {
   @Listen('p6ResetCustomDefinitions')
   onP6ResetCustomDefinitions(event: CustomEvent<ResetDefinitionsDetail>): void {
     if (event.detail.reset) {
-      this.columns = this.definitions.map(fromDefinition);
+      this.columns = this.defaultDefinitions === undefined ? this.definitions.map(fromDefinition) : this.defaultDefinitions.map(fromDefinition);
     }
 
     this.p6GridConfigurationChange.emit({ columns: this.columns });

--- a/packages/core/src/components/organisms/p6-grid/readme.md
+++ b/packages/core/src/components/organisms/p6-grid/readme.md
@@ -8,6 +8,7 @@
 | -------------------------- | --------- | ---------------------------------------- | --------------------------------------------------------------- | ----------- |
 | `customContextMenu`        | --        | Display a context menu based on row data | `((row: Row<Record<string, unknown>>) => Element) \| undefined` | `undefined` |
 | `data` _(required)_        | --        | Grid rows                                | `Record<string, unknown>[]`                                     | `undefined` |
+| `defaultDefinitions`       | --        | Default grid headers                     | `ColumnDefinition<Record<string, unknown>>[] \| undefined`      | `undefined` |
 | `definitions` _(required)_ | --        | Grid headers                             | `ColumnDefinition<Record<string, unknown>>[]`                   | `undefined` |
 | `loading`                  | `loading` | Display spinner                          | `boolean`                                                       | `false`     |
 


### PR DESCRIPTION
Add a defaultDefinitions property to be able to reset the columns.

Closes #12