### PR TITLE
fix(p6-grid): the configured sort is not applied on loading

### DIFF
--- a/packages/core/src/components/organisms/p6-grid/core/column.ts
+++ b/packages/core/src/components/organisms/p6-grid/core/column.ts
@@ -37,7 +37,7 @@ export function fromDefinition<T extends DataItem>(column: ColumnDefinition<T>):
     hidden: column.hidden || false,
     width: column.width || 100,
     align: column.align || Alignment.center,
-    sortOrder: column.sortOrder || SortOrder.none,
+    sortOrder: column.sortOrder === undefined ? SortOrder.none : column.sortOrder,
     disableHeaderMenu: column.disableHeaderMenu || false,
     getValue: column.getValue || defaultGetValue,
     setValue: column.setValue || defaultSetValue,

--- a/packages/core/src/components/organisms/p6-grid/p6-grid.stories.ts
+++ b/packages/core/src/components/organisms/p6-grid/p6-grid.stories.ts
@@ -1,7 +1,7 @@
 import { JSX } from '@stencil/core';
 import { Components } from '../../../components';
 import { ComponentProps, getElement, makeStory, Props } from '../../../shared/storybook';
-import { Alignment } from '../../../shared/types';
+import { Alignment, SortOrder } from '../../../shared/types';
 import { ColumnDefinition, DataItem, Row } from './core/entities';
 
 const component = 'p6-grid';
@@ -27,6 +27,7 @@ const definitions: ColumnDefinition<DataItem>[] = [
     field: 'first',
     editable: true,
     width: 150,
+    sortOrder: SortOrder.none,
   },
   {
     label: 'Second Col',
@@ -34,6 +35,7 @@ const definitions: ColumnDefinition<DataItem>[] = [
     editable: true,
     width: 150,
     align: Alignment.end,
+    sortOrder: SortOrder.desc,
   },
   {
     id: 'third',

--- a/packages/core/src/components/organisms/p6-grid/p6-grid.tsx
+++ b/packages/core/src/components/organisms/p6-grid/p6-grid.tsx
@@ -285,7 +285,11 @@ export class P6Grid {
     this.columns = this.definitions.map(fromDefinition);
     this.rows = this.data.map(fromData);
 
-    [this.sortedBy] = this.columns;
+    this.sortedBy = this.columns.find(col => col.sortable !== false && (col.sortOrder === SortOrder.asc || col.sortOrder === SortOrder.desc));
+
+    if (this.sortedBy !== undefined) {
+      this.columns = this.columns.map(col => (col.id === this.sortedBy?.id ? col : { ...col, sortOrder: SortOrder.none }));
+    }
 
     this.l10n = await getL10n(this.host);
   }

--- a/packages/core/src/components/organisms/p6-grid/test/__snapshots__/p6-grid.spec.tsx.snap
+++ b/packages/core/src/components/organisms/p6-grid/test/__snapshots__/p6-grid.spec.tsx.snap
@@ -121,6 +121,71 @@ exports[`p6-grid should render a grid with on row 1`] = `
 </p6-grid>
 `;
 
+exports[`p6-grid should render a sorted grid 1`] = `
+<p6-grid>
+  <mock:shadow-root>
+    <div class="row-context-menu undefined"></div>
+    <p6-grid-actions>
+      <slot name="actions"></slot>
+    </p6-grid-actions>
+    <p6-grid-options></p6-grid-options>
+    <p6-grid-header>
+      <p6-grid-header-cell sortorder="2" width="150">
+        First Col
+      </p6-grid-header-cell>
+      <p6-grid-header-cell sortorder="2" width="100">
+        Second Col
+      </p6-grid-header-cell>
+      <p6-grid-header-cell sortorder="0" width="100">
+        third
+      </p6-grid-header-cell>
+      <p6-grid-header-cell sortorder="2" width="100">
+        Last
+      </p6-grid-header-cell>
+    </p6-grid-header>
+    <p6-grid-body>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+      <p6-grid-row>
+        <p6-grid-cell align="1" editable="" width="150"></p6-grid-cell>
+        <p6-grid-cell align="2" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" editable="" width="100"></p6-grid-cell>
+        <p6-grid-cell align="1" width="100"></p6-grid-cell>
+      </p6-grid-row>
+    </p6-grid-body>
+    <slot></slot>
+  </mock:shadow-root>
+</p6-grid>
+`;
+
 exports[`p6-grid should render an empty grid 1`] = `
 <p6-grid>
   <mock:shadow-root></mock:shadow-root>

--- a/packages/core/src/components/organisms/p6-grid/test/p6-grid.spec.tsx
+++ b/packages/core/src/components/organisms/p6-grid/test/p6-grid.spec.tsx
@@ -1,6 +1,6 @@
 import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
-import { Alignment } from '../../../../shared/types';
+import { Alignment, SortOrder } from '../../../../shared/types';
 import { ColumnDefinition, DataItem } from '../core/entities';
 import { P6Grid } from '../p6-grid';
 
@@ -92,6 +92,7 @@ describe('p6-grid', () => {
     });
     expect(page.root).toMatchSnapshot();
   });
+
   it('should render a grid with on row', async () => {
     const page = await newSpecPage({
       components: [P6Grid],
@@ -101,6 +102,7 @@ describe('p6-grid', () => {
     });
     expect(page.root).toMatchSnapshot();
   });
+
   it('should display a spinner', async () => {
     const page = await newSpecPage({
       components: [P6Grid],
@@ -110,6 +112,7 @@ describe('p6-grid', () => {
     });
     expect(page.body.childNodes[0]).toMatchSnapshot();
   });
+
   it('should display an empty message', async () => {
     const page = await newSpecPage({
       components: [P6Grid],
@@ -118,5 +121,19 @@ describe('p6-grid', () => {
       },
     });
     expect(page.body.childNodes[0]).toMatchSnapshot();
+  });
+
+  it('should render a sorted grid', async () => {
+    const alteredDefinitions = [...definitions];
+
+    alteredDefinitions[2].sortOrder = SortOrder.asc;
+
+    const page = await newSpecPage({
+      components: [P6Grid],
+      template: () => {
+        return <p6-grid definitions={definitions} data={testItems} />;
+      },
+    });
+    expect(page.root).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
initiates the sorting with the first column found having the elements needed for sorting