### PR TITLE
style(p6-file): fixes the position of the placeholder

### DIFF
--- a/packages/core/src/components/atoms/p6-file/p6-file.scss
+++ b/packages/core/src/components/atoms/p6-file/p6-file.scss
@@ -182,7 +182,7 @@ $icon-dimensions-small: $size-small !default;
     }
 
     .file-label {
-      align-items: stretch;
+      align-items: center;
       display: flex;
       cursor: pointer;
       justify-content: flex-start;


### PR DESCRIPTION
**Before :** 
![image](https://user-images.githubusercontent.com/304983/103786281-8d12a000-503c-11eb-984a-2d4ba4c1b8a0.png)

**After :** 
![image](https://user-images.githubusercontent.com/304983/103788258-eaa7ec00-503e-11eb-9504-9482afb55a77.png)